### PR TITLE
moved the xunit runner into the generic part of the csproj files

### DIFF
--- a/templates/Normal/MyPackage.Specs/MyPackage.Specs.csproj
+++ b/templates/Normal/MyPackage.Specs/MyPackage.Specs.csproj
@@ -8,23 +8,16 @@
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-      <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      </PackageReference>
-    </ItemGroup>
-
     <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-      <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      </PackageReference>
     </ItemGroup>
 
     <ItemGroup>
       <PackageReference Include="xunit" Version="2.5.0" />
+      <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      </PackageReference>
       <PackageReference Include="FluentAssertions" Version="7.1.0" />
       <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
       <PackageReference Include="coverlet.collector" Version="6.0.3" PrivateAssets="all">

--- a/templates/SourceOnly/MyPackage.Specs/MyPackage.Specs.csproj
+++ b/templates/SourceOnly/MyPackage.Specs/MyPackage.Specs.csproj
@@ -8,23 +8,16 @@
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-      <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      </PackageReference>
-    </ItemGroup>
-
     <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-      <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      </PackageReference>
     </ItemGroup>
 
     <ItemGroup>
       <PackageReference Include="xunit" Version="2.5.0" />
+      <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      </PackageReference>
       <PackageReference Include="FluentAssertions" Version="7.1.0" />
       <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
       <PackageReference Include="coverlet.collector" Version="6.0.3" PrivateAssets="all">


### PR DESCRIPTION
The xunit runner doesnt have to be net472 of net6 framework specific. 

