### PR TITLE
Enabled NuGet Auditing and bumped all dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ It includes:
 * Customized release notes templates for GitHub connected to pull requests labels.
 * A test project using [xUnit](https://xunit.net/) and [Fluent Assertions 7](https://fluentassertions.com/)
 * Validation of the public API of the library against snapshots using [Verify](https://github.com/VerifyTests/Verify)
+* NuGet auditing
 
 ### What's so special about that?
 
@@ -69,6 +70,10 @@ Contact me through [Email](mailto:dennis.doomen@avivasolutions.nl), [Bluesky](ht
 This repository is available as [a NuGet package](https://www.nuget.org/packages/DotNetLibraryPackageTemplates) on https://nuget.org. To install it, use the following command-line:
 
 `dotnet new install DotNetLibraryPackageTemplates`
+
+To update the templates, use the following command-line
+
+`dotnet new update`
 
 ## How do I use it?
 
@@ -100,7 +105,16 @@ The template makes a lot of assumptions, so after generating the project, there'
 * Determine if you want to use API verification against snapshots
 * Study the Nuke `build.cs` file or invoking it through `build.ps1 -plan` to see how it works
 * See if all dependencies are up-to-date
+* Configure NuGet auditing (see next paragraph)
 * Adjust the `funding.yml` to allow people to sponsor your project
+
+## Additional things to be aware of
+
+### About NuGet auditing
+By default, a `dotnet restore` will also check the the NuGet packages [for any vulnerabilities](https://learn.microsoft.com/en-us/nuget/concepts/auditing-packages). If you run into those, there are a couple of options you can take.
+1. Update the dependencies to a version that resolve the vulnerability
+1. Update the `WarningsNotAsErrors` element in the `Directory.Build.Props` file to include the relevant `NU190x` error codes as listed [here](https://learn.microsoft.com/en-us/nuget/concepts/auditing-packages#warning-codes).
+1. Disable auditing entirely by setting the `NuGetAudit` element to `false` in that same `Directory.Build.Props` file.
 
 ### About API verification
 

--- a/templates/Source/Build/_build.csproj
+++ b/templates/Source/Build/_build.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="9.0.3" />
-    <PackageReference Include="Nuke.Components" Version="9.0.3" />
+    <PackageReference Include="Nuke.Common" Version="9.0.4" />
+    <PackageReference Include="Nuke.Components" Version="9.0.4" />
     <PackageDownload Include="ReportGenerator" Version="[5.2.0]" />
     <PackageDownload Include="GitVersion.Tool" Version="[6.0.2]" />
   </ItemGroup>

--- a/templates/Source/Directory.Build.props
+++ b/templates/Source/Directory.Build.props
@@ -2,8 +2,11 @@
   <PropertyGroup>
     <LangVersion>11.0</LangVersion>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1902;NU1903</WarningsNotAsErrors> <!-- disable EOL warnings -->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NuGetAuditMode>all</NuGetAuditMode>
+    <NuGetAudit>true</NuGetAudit>
     <NoWarn>1591;1573</NoWarn>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors)</WarningsNotAsErrors> <!-- disable EOL warnings -->
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
@@ -20,7 +23,7 @@
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4">
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="4.14.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -32,11 +35,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.Analyzers" Version="4.12.10">
+    <PackageReference Include="Roslynator.Analyzers" Version="4.13.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Meziantou.Analyzer" Version="2.0.186">
+    <PackageReference Include="Meziantou.Analyzer" Version="2.0.201">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/templates/Source/MyPackage.ApiVerificationTests/MyPackage.ApiVerificationTests.csproj
+++ b/templates/Source/MyPackage.ApiVerificationTests/MyPackage.ApiVerificationTests.csproj
@@ -15,9 +15,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="PublicApiGenerator" Version="11.3.0" />
+    <PackageReference Include="PublicApiGenerator" Version="11.4.6" />
     <PackageReference Include="Verify.DiffPlex" Version="3.1.2" />
-    <PackageReference Include="Verify.Xunit" Version="28.9.0" />
+    <PackageReference Include="Verify.Xunit" Version="30.3.1" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4"/>
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1"/>
   </ItemGroup>
 
 </Project>

--- a/templates/Source/MyPackage.Specs/MyPackage.Specs.csproj
+++ b/templates/Source/MyPackage.Specs/MyPackage.Specs.csproj
@@ -9,10 +9,12 @@
     </PropertyGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     </ItemGroup>
 
     <ItemGroup>
+      <PackageReference Include="System.Net.Http" Version="4.3.4"/>
+      <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1"/>
       <PackageReference Include="xunit" Version="2.5.0" />
       <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
         <PrivateAssets>all</PrivateAssets>
@@ -20,7 +22,7 @@
       </PackageReference>
       <PackageReference Include="FluentAssertions" Version="7.1.0" />
       <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
-      <PackageReference Include="coverlet.collector" Version="6.0.3" PrivateAssets="all">
+      <PackageReference Include="coverlet.collector" Version="6.0.4" PrivateAssets="all">
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       </ItemGroup>


### PR DESCRIPTION
This pull request introduces enhancements to the documentation and upgrades to dependencies across multiple project files. Key updates include the addition of NuGet auditing features, improved guidance in the `README.md`, and updates to package versions for better compatibility and security.

It solves #14 

### Documentation Updates:
* Added information about NuGet auditing in the `README.md`, including steps to configure and handle vulnerabilities.
* Included instructions for updating templates using the `dotnet new update` command in the `README.md`.

### Dependency Updates:
* Upgraded `Nuke.Common` and `Nuke.Components` package versions from `9.0.3` to `9.0.4` in `_build.csproj`.
* Updated analyzer and utility packages in `Directory.Build.props`:
  - `Microsoft.CodeAnalysis.BannedApiAnalyzers` from `3.3.4` to `4.14.0`.
  - `Roslynator.Analyzers` from `4.12.10` to `4.13.1`.
  - `Meziantou.Analyzer` from `2.0.186` to `2.0.201`.
* Enhanced test project dependencies:
  - Upgraded `PublicApiGenerator` to `11.4.6` and `Verify.Xunit` to `30.3.1` in `MyPackage.ApiVerificationTests.csproj`. Added `System.Net.Http` and `System.Text.RegularExpressions` packages for extended functionality.
  - Updated `Microsoft.NET.Test.Sdk` to `17.13.0` and `coverlet.collector` to `6.0.4` in `MyPackage.Specs.csproj`. Added `System.Net.Http` and `System.Text.RegularExpressions` packages.

### Configuration Enhancements:
* Enabled NuGet auditing by adding `NuGetAuditMode` and `NuGetAudit` properties in `Directory.Build.props`.