### PR TITLE
Add Azure DevOps pipeline template

### DIFF
--- a/templates/Source/Build/azure-pipelines.yaml
+++ b/templates/Source/Build/azure-pipelines.yaml
@@ -1,0 +1,35 @@
+{{~ if azdo ~}}
+pr:
+  - main
+
+trigger:
+  branches:
+    include:
+      - main
+  tags:
+    include:
+      - "*"
+
+pool:
+  vmImage: windows-latest
+
+stages:
+  - stage: build
+    displayName: "Build, Pack and Push to Feed"
+    jobs:
+      - job:
+        workspace:
+          clean: all
+        timeoutInMinutes: 10 # how long to run the job before automatically cancelling
+        cancelTimeoutInMinutes: 1 # how much time to give 'run always even if cancelled tasks' before stopping them
+        displayName: "Build, Pack and Push to Feed"
+        steps:
+          - task: NuGetAuthenticate@1
+            displayName: "Authenticate Azure Pipeline to Azure Artifacts"
+          - script: './build.cmd'
+            displayName: 'Run Nuke'
+            env:
+              NugetArtifactsApiKey: "Dummy" # Ignored but required https://github.com/NuGet/Home/issues/7792#issuecomment-631683878
+              BranchSpec: $(Build.SourceBranch)
+              BuildNumber: $(Build.BuildNumber)
+{{~ end ~}}


### PR DESCRIPTION
Adds an Azure Pipelines YAML template (`azure-pipelines.yaml`) to the library starter kit templates.

The pipeline:
- Triggers on PRs and pushes to `main`, as well as tag pushes
- Runs on `windows-latest`
- Authenticates to Azure Artifacts via `NuGetAuthenticate@1`
- Executes the Nuke build script with the appropriate environment variables (`BranchSpec`, `BuildNumber`, `NugetArtifactsApiKey`)

The template is conditionally rendered via the `{{~ if azdo ~}}` guard so it only appears when the `azdo` option is selected during project scaffolding.

Closes #71