### PR TITLE
Prevent underscore-prefixed fields via dedicated naming rule

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -69,6 +69,16 @@ dotnet_naming_symbols.constant_fields.required_modifiers = const
 
 dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 
+# name all non-const fields using camelCase, which also prevents them from being prefixed with an underscore
+# (not just through SA1309, but through a dedicated naming rule so it can't be disabled by disabling StyleCop)
+dotnet_naming_rule.fields_should_be_camel_case.severity = error
+dotnet_naming_rule.fields_should_be_camel_case.symbols  = non_const_fields
+dotnet_naming_rule.fields_should_be_camel_case.style    = camel_case_style
+
+dotnet_naming_symbols.non_const_fields.applicable_kinds = field
+
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+
 # Code style defaults
 csharp_using_directive_placement = outside_namespace:warning
 dotnet_sort_system_directives_first = true

--- a/templates/Source/.editorconfig
+++ b/templates/Source/.editorconfig
@@ -70,6 +70,16 @@ dotnet_naming_symbols.constant_fields.required_modifiers = const
 
 dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 
+# name all non-const fields using camelCase, which also prevents them from being prefixed with an underscore
+# (not just through SA1309, but through a dedicated naming rule so it can't be disabled by disabling StyleCop)
+dotnet_naming_rule.fields_should_be_camel_case.severity = error
+dotnet_naming_rule.fields_should_be_camel_case.symbols  = non_const_fields
+dotnet_naming_rule.fields_should_be_camel_case.style    = camel_case_style
+
+dotnet_naming_symbols.non_const_fields.applicable_kinds = field
+
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+
 # Code style defaults
 csharp_using_directive_placement = outside_namespace:warning
 dotnet_sort_system_directives_first = true


### PR DESCRIPTION
## Summary
Closes #90.

Previously, underscore-prefixed field names (`_foo`) were only discouraged via StyleCop's `SA1309`, which can be disabled independently of other naming enforcement. This adds a dedicated `dotnet_naming_rule` that enforces `camelCase` for all non-const fields, which rejects any leading underscore regardless of whether StyleCop analyzers are enabled.

## Changes
- `.editorconfig`: added `fields_should_be_camel_case` naming rule (severity `error`) for all fields, ordered after the existing `constant_fields_should_be_pascal_case` rule so `const` fields keep using PascalCase.
- `templates/Source/.editorconfig`: same rule added, since this file seeds new projects generated from the template.

## Verification
- `dotnet build DotNetPackageTemplates.sln` succeeds with 0 warnings/errors.
- No existing field in the repo currently uses an underscore prefix, so this is a non-breaking, enforcement-only change.