### PR TITLE
Bump template test projects to xUnit v3

### DIFF
--- a/templates/Source/MyPackage.Specs/MyPackage.Specs.csproj
+++ b/templates/Source/MyPackage.Specs/MyPackage.Specs.csproj
@@ -6,6 +6,7 @@
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
         <IsPackable>false</IsPackable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
@@ -15,7 +16,7 @@
     <ItemGroup>
       <PackageReference Include="System.Net.Http" Version="4.3.4"/>
       <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1"/>
-      <PackageReference Include="xunit" Version="2.9.3" />
+      <PackageReference Include="xunit.v3" Version="3.2.2" />
       <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/templates/Source/MyPackage.Specs/MyPackage.Specs.csproj
+++ b/templates/Source/MyPackage.Specs/MyPackage.Specs.csproj
@@ -4,7 +4,7 @@
         <TargetFrameworks>net10.0;net472</TargetFrameworks>
         <LangVersion>default</LangVersion>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-        <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+        <TestingPlatformDotnetTestSupport>false</TestingPlatformDotnetTestSupport>
         <IsPackable>false</IsPackable>
         <OutputType>Exe</OutputType>
     </PropertyGroup>


### PR DESCRIPTION
Keeps the library template current with xUnit's v3 major release rather than staying on the older v2 line.

## Changes

- Replace `xunit` (2.9.3) with `xunit.v3` (3.2.2) in `MyPackage.Specs` and `MyPackage.ApiVerificationTests`
- Add `<OutputType>Exe</OutputType>` to both test projects, required because xUnit v3 tests run via an in-process console runner rather than a class library
- Replace `Verify.Xunit` with `Verify.XunitV3` (31.25.0) in `MyPackage.ApiVerificationTests`, since `Verify.Xunit` only supports xUnit v2 internals

`xunit.runner.visualstudio` was already on 3.1.5 (v3-compatible) and needed no change. No test source changes were required since the template didn't use any of the APIs affected by xUnit v3's breaking changes (`async void` tests, custom `Fact`/`Theory` attributes, `Xunit.Abstractions`, etc.).

## Verification

Rendered the template variants via `.\build.cmd PrepareTemplates` and ran `dotnet build` / `dotnet test` against the rendered "Normal" variant. Build succeeded for all target frameworks (net10.0, net472), and `MyPackage.Specs` tests passed.

Note: `MyPackage.ApiVerificationTests` failed locally with a `VerifiedLineEndingException`, but this is a pre-existing, unrelated issue caused by Windows git checkout adding CRLF to the `.verified.txt` snapshot files (no `.gitattributes` rule pins them to LF) - not something introduced by this change.