### PR TITLE
Add optional SonarCloud analysis to generated project template

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ It includes:
 * Support for both GitHub and Azure DevOps Repositories/Pipelines
 * Can create projects for binary or source-only packages
 * Code coverage using [Coverlet](https://github.com/coverlet-coverage/coverlet) and [Coveralls.io](https://coveralls.io/)
+* Optional static analysis and quality gates through [SonarCloud](https://sonarcloud.io) (just add a `SONAR_TOKEN` secret to opt in)
 * Static code analysis using Roslyn analyzers [StyleCopAnalyzers](https://github.com/DotNetAnalyzers/StyleCopAnalyzers), [Roslynator](https://github.com/dotnet/roslynator), [CSharpGuidelinesAnalyzer](https://github.com/bkoelman/CSharpGuidelinesAnalyzer) and [Meziantou](https://github.com/meziantou/Meziantou.Framework).
 * Auto-formatting using (a slightly opinionated) `.editorconfig` and settings honored by [JetBrains Rider](https://www.jetbrains.com/rider/) and [ReSharper](https://www.jetbrains.com/resharper/)
 * A [Fallout](https://fallout.build/) C# build script that you can run locally as well as in your CI/CD pipeline

--- a/templates/Source/.github/workflows/build.yml
+++ b/templates/Source/.github/workflows/build.yml
@@ -38,11 +38,19 @@ jobs:
           3.0.x
           6.0.x
 
+    - name: Setup Java (required by SonarCloud's scanner)
+      uses: actions/setup-java@v5
+      if: ${{ secrets.SONAR_TOKEN != '' }}
+      with:
+        distribution: 'temurin'
+        java-version: '17'
+
     - name: Run NUKE
       run: ./build.ps1
       env:
         NuGetApiKey: ${{ secrets.NUGETAPIKEY }}
         GitHubApiKey: ${{ secrets.GITHUB_TOKEN }}
+        SonarToken: ${{ secrets.SONAR_TOKEN }}
 
     - name: Check for 'lcov.info' existence
       id: check_files

--- a/templates/Source/Build/Build.cs
+++ b/templates/Source/Build/Build.cs
@@ -13,10 +13,16 @@ using Fallout.Common.Tools.Coverlet;
 using Fallout.Common.Tools.DotNet;
 using Fallout.Common.Tools.GitVersion;
 using Fallout.Common.Tools.ReportGenerator;
+{{~ if !azdo ~}}
+using Fallout.Common.Tools.SonarScanner;
+{{~ end ~}}
 using Fallout.Common.Utilities;
 using Fallout.Common.Utilities.Collections;
 using static Fallout.Common.Tools.DotNet.DotNetTasks;
 using static Fallout.Common.Tools.ReportGenerator.ReportGeneratorTasks;
+{{~ if !azdo ~}}
+using static Fallout.Common.Tools.SonarScanner.SonarScannerTasks;
+{{~ end ~}}
 using static Serilog.Log;
 
 class Build : FalloutBuild
@@ -61,6 +67,23 @@ class Build : FalloutBuild
     [Parameter("The key to use for scanning packages on GitHub")]
     [Secret]
     readonly string GitHubApiKey;
+
+{{~ if !azdo ~}}
+    [Parameter("The token used to authenticate with SonarCloud. Leave empty to skip SonarCloud analysis entirely.")]
+    [Secret]
+    readonly string SonarToken;
+
+    // Defaults to the GitHub repository owner and "owner_repo", so no extra
+    // dotnet-new parameters are required to opt in to SonarCloud analysis.
+    string SonarOrganization => GitHubActions?.RepositoryOwner;
+
+    string SonarProjectKey => GitHubActions?.Repository.Replace('/', '_');
+
+    [Parameter("The URL of the SonarQube/SonarCloud server to analyze against.")]
+    readonly string SonarHostUrl = "https://sonarcloud.io";
+
+    bool UseSonarCloud => !string.IsNullOrWhiteSpace(SonarToken);
+{{~ end ~}}
 
     [Solution(GenerateProjects = true)]
     readonly Solution Solution;
@@ -109,9 +132,30 @@ class Build : FalloutBuild
                 .EnableNoCache());
         });
 
+{{~ if !azdo ~}}
+    Target SonarBegin => _ => _
+        .DependsOn(Restore)
+        .OnlyWhenDynamic(() => UseSonarCloud)
+        .Executes(() =>
+        {
+            Information("Starting SonarCloud analysis for project {ProjectKey}", SonarProjectKey);
+
+            SonarScannerBegin(s => s
+                .SetProjectKey(SonarProjectKey)
+                .SetOrganization(SonarOrganization)
+                .SetServer(SonarHostUrl)
+                .SetToken(SonarToken)
+                .SetVersion(GitVersion.SemVer)
+                .SetGenericCoveragePaths(TestResultsDirectory / "reports" / "SonarQube.xml"));
+        });
+{{~ end ~}}
+
     Target Compile => _ => _
         .DependsOn(CalculateNugetVersion)
         .DependsOn(Restore)
+{{~ if !azdo ~}}
+        .DependsOn(SonarBegin)
+{{~ end ~}}
         .Executes(() =>
         {
             ReportSummary(s => s
@@ -201,7 +245,7 @@ class Build : FalloutBuild
 {{~ else ~}}
             ReportGenerator(s => s
 				.AddReports(TestResultsDirectory / "**/coverage.cobertura.xml")
-                .AddReportTypes(ReportTypes.lcov, ReportTypes.Html)
+                .AddReportTypes(ReportTypes.lcov, ReportTypes.Html, ReportTypes.SonarQube)
                 .SetTargetDirectory(TestResultsDirectory / "reports")
                 .AddFileFilters("-*.g.cs"));
 
@@ -258,6 +302,17 @@ class Build : FalloutBuild
             (ArtifactsDirectory / "Readme.md").WriteAllText(readmeContent);
         });
 
+{{~ if !azdo ~}}
+    Target SonarEnd => _ => _
+        .DependsOn(RunTests, GenerateCodeCoverageReport, ApiChecks)
+        .OnlyWhenDynamic(() => UseSonarCloud)
+        .Executes(() =>
+        {
+            SonarScannerEnd(s => s
+                .SetToken(SonarToken));
+        });
+{{~ end ~}}
+
     Target Pack => _ => _
         .DependsOn(ScanPackages)
         .DependsOn(PreparePackageReadme)
@@ -265,6 +320,9 @@ class Build : FalloutBuild
         .DependsOn(ApiChecks)
         .DependsOn(GenerateCodeCoverageReport)
         {{~ if azdo }}.DependsOn(PublishTestResults){{~ end ~}}
+{{~ if !azdo ~}}
+        .DependsOn(SonarEnd)
+{{~ end ~}}
         .Executes(() =>
         {
             ReportSummary(s => s

--- a/templates/Source/README.md
+++ b/templates/Source/README.md
@@ -16,6 +16,7 @@
 {{~ if !azdo ~}}
 [![](https://img.shields.io/github/actions/workflow/status/your-github-username/mypackage/build.yml?branch=main)](https://github.com/your-github-username/mypackage/actions?query=branch%3amain)
 [![Coveralls branch](https://img.shields.io/coverallsCoverage/github/your-github-username/mypackage?branch=main)](https://coveralls.io/github/your-github-username/mypackage?branch=main)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=your-github-username_mypackage&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=your-github-username_mypackage)
 [![](https://img.shields.io/github/release/your-github-username/mypackage.svg?label=latest%20release&color=007edf)](https://github.com/your-github-username/mypackage/releases/latest)
 [![](https://img.shields.io/nuget/dt/mypackage.svg?label=downloads&color=007edf&logo=nuget)](https://www.nuget.org/packages/mypackage)
 [![](https://img.shields.io/librariesio/dependents/nuget/mypackage.svg?label=dependent%20libraries)](https://libraries.io/nuget/mypackage)
@@ -62,6 +63,9 @@ The template makes a lot of assumptions, so after generating the project, there'
 * For the source-only packages, update the `.nuspec` file so it represents your information.
 {{~ end ~}}
 * Alter the coverage service that is being used.
+{{~ if !azdo ~}}
+* Optionally enable [SonarCloud](https://sonarcloud.io) analysis: create a project on sonarcloud.io for this repository, then add a `SONAR_TOKEN` secret to the GitHub repository. The build silently skips SonarCloud analysis when this secret isn't set.
+{{~ end ~}}
 * Determine if you want to use API verification against snapshots
 * Study the Nuke `build.cs` file or invoking it through `build.ps1 -plan` to see how it works
 * See if all dependencies are up-to-date


### PR DESCRIPTION
Closes #30

Adds opt-in SonarCloud analysis to the `templates/Source/...` project template that this repo generates (GitHub Actions variants only — Azure DevOps variants are untouched since SonarCloud on ADO needs a different marketplace-extension-based setup and wasn't requested).

## What changed
- **`templates/Source/Build/Build.cs`**: new `SonarToken` (`[Secret]`), `SonarHostUrl` parameters, plus `SonarOrganization`/`SonarProjectKey`/`UseSonarCloud` computed from the GitHub Actions context (no new `dotnet new` symbols needed). Added `SonarBegin`/`SonarEnd` Nuke targets wired into `Compile`/`Pack`, both gated with `OnlyWhenDynamic(() => UseSonarCloud)` so they're skipped entirely when `SonarToken` isn't set. Coverage is fed into Sonar via ReportGenerator's built-in `SonarQube` report type (`sonar.coverageReportPaths`), so no extra Coverlet format juggling was needed.
- **`templates/Source/.github/workflows/build.yml`**: adds an `actions/setup-java@v5` step (JRE required by `dotnet-sonarscanner`), gated on `secrets.SONAR_TOKEN != ''`, and passes `SonarToken: ${{ secrets.SONAR_TOKEN }}` to the build step.
- **`templates/Source/README.md`**: SonarCloud badge (in the existing badge row) and a bullet explaining how to opt in (create a SonarCloud project, add a `SONAR_TOKEN` secret).
- **Root `README.md`**: mentions the new optional SonarCloud support in the feature list.

## Design
Non-breaking by default — a generated project that never sets up SonarCloud still gets a fully green build, mirroring the existing Coveralls no-op pattern.

## Validation
- Ran this repo's own Nuke build (`Compile`/`Pack` targets that Scriban-render all 6 template variants) — succeeded with no templating errors.
- Manually inspected rendered `Normal` and `NormalAzdo` variants: SonarCloud code/YAML appears only in the GitHub Actions (non-azdo) variant; the Azdo variant has zero Sonar references.
- Compiled the rendered `Normal` variant's `Build.cs` directly with `dotnet build` — 0 errors, 0 warnings.